### PR TITLE
Fix for dict unfolding

### DIFF
--- a/tests/test_vyper.py
+++ b/tests/test_vyper.py
@@ -15,6 +15,13 @@ try:
 except NameError:
     FileNotFoundError = OSError
 
+yaml_doublication_in_nesting = '''
+sweet:
+  home:
+    alabama: yeap
+  job:
+    alabama: noway
+'''
 
 yaml_example = '''Hacker: true
 name: steve
@@ -151,6 +158,14 @@ class TestVyper(unittest.TestCase):
         self.assertEqual('steve', self.v.get('name'))
         self.assertEqual(35, self.v.get('age'))
 
+    def test_yaml_duplication_nested(self):
+
+        self.v.set_config_type('yaml')
+        r = yaml.dump(yaml_doublication_in_nesting)
+        self.v._unmarshall_reader(r, self.v._config)
+        self.assertEqual('yeap', self.v.get('sweet.home.alabama'))
+        self.assertEqual('noway', self.v.get('sweet.job.alabama'))
+
     def test_override(self):
         self.v.set('age', 40)
         self.assertEqual(40, self.v.get('age'))
@@ -165,7 +180,7 @@ class TestVyper(unittest.TestCase):
         self.v.set('years', 45)
         self.assertEqual(45, self.v.get('age'))
 
-    #def test_alias_in_config_file(self):
+    # def test_alias_in_config_file(self):
     #    # the config file specifies "beard". If we make this an alias for
     #    # "hasbeard", we still want the old config file to work with beard.
     #    self._init_yaml()

--- a/vyper/vyper.py
+++ b/vyper/vyper.py
@@ -162,14 +162,16 @@ class Vyper(object):
                 return True
         return False
 
-    def _search_dict(self, d, key):
-        if key in d:
-            return d[key]
-        for k, v in d.items():
-            if isinstance(v, dict):
-                item = self._search_dict(v, key)
-                if item is not None:
-                    return item
+    def _search_dict(self, d, keys):
+        if not keys:
+            return d
+        for key in keys:
+            if key in d and not isinstance(d[key], dict):
+                return d[key]
+            elif key in d:
+                return self._search_dict(d[key], keys[1::])
+            else:
+                return None
 
     def get(self, key):
         """Vyper is essentially repository for configurations.
@@ -186,7 +188,7 @@ class Vyper(object):
         if val is None:
             source = self._find(path[0].lower())
             if source is not None and isinstance(source, dict):
-                val = self._search_dict(source, path[-1])
+                val = self._search_dict(source, path[1::])
 
         if val is None:
             return None
@@ -322,7 +324,7 @@ class Vyper(object):
 
             source = self._find(path[0])
             if source is not None and isinstance(source, dict):
-                val = self._search_dict(source, path[-1])
+                val = self._search_dict(source, path[1::])
                 log.debug('{0} found in nested config: {1}'.format(key, val))
                 return val
 
@@ -349,7 +351,7 @@ class Vyper(object):
         if val is None:
             source = self._find(path[0].lower())
             if source is not None and isinstance(source, dict):
-                val = self._search_dict(source, path[-1])
+                val = self._search_dict(source, path[1::])
 
         return val is not None
 


### PR DESCRIPTION
Dict unfolding (_search_dict function) now operates with array of items
to search. Order of elements in list - is the order of unfolding the
dicts.
For example to unfold {'a':{'b':'c'}}, we must pass an array ['a','b']
Passing full path as aruments required for the following situation.
test ={'root':
         {'x':
              {'test': True},
          'y':
              {'test': False}
          }
     }
Before this path  we passed only 'test' to the search_dict functino and first math has
been returned. This was wrong for example for get('x.y.test') because
True was returned.

Test added.