### PR TITLE
Fixes case insensitive complex env binding

### DIFF
--- a/tests/test_vyper.py
+++ b/tests/test_vyper.py
@@ -84,6 +84,14 @@ json_camel_case_example = {
         '0.42',
         '0.82',
     ],
+    "Icings": {
+        "Regular": {
+            "Types": ["plain", "glazed"]
+        },
+        "Premium": {
+            "Types": ["passionfruit", "chocolate"]
+        }
+    }
 }
 
 
@@ -457,6 +465,25 @@ class TestVyper(unittest.TestCase):
 
         self.v.bind_arg('eYEs', vars(args[0])['eyeballs'])
         self.assertEqual('green', self.v.get('eyes'))
+
+
+    def test_complex_bound_case_sensitivity(self):
+        self._init_json(fixture=json_camel_case_example)
+        self.assertEqual(['plain', 'glazed'], self.v.get('Icings.Regular.Types'))
+
+        self.v.bind_env('IcIngs.ReGular.TyPes', 'REGULAR_ICING')
+        self.v.bind_env('IcIngs.Premium', 'PREMIUM_ICING')
+        os.environ['REGULAR_ICING'] = 'chocolate'
+        os.environ['PREMIUM_ICING'] = 'Sold Out'
+
+        self.assertEqual('chocolate', self.v.get('Icings.Regular.Types'))
+        self.assertEqual('Sold Out', self.v.get('Icings.Premium'))
+        self.assertEqual('chocolate', self.v.get('Icings.Regular')['Types'])
+        
+        icings = self.v.get('icings')
+        self.assertEqual('Sold Out', icings['Premium'])
+        self.assertEqual({'Types': 'chocolate'}, icings['Regular'])
+
 
     def test_sub(self):
         self.v.set_config_type('yaml')

--- a/vyper/vyper.py
+++ b/vyper/vyper.py
@@ -353,7 +353,7 @@ class Vyper(object):
         if isinstance(env_key, list):
             parent = self._find_insensitive(key, self._config)
             found_in_env = False
-            log.debug(f'Found env key parent {key}: {parent}')
+            log.debug('Found env key parent {0}: {1}'.format(key, parent))
 
             for item in env_key:
                 log.debug('{0} registered as env var parent {1}:'.format(key, item['env_key']))

--- a/vyper/vyper.py
+++ b/vyper/vyper.py
@@ -348,7 +348,7 @@ class Vyper(object):
                 return val
 
         env_key = self._find_insensitive(key, self._env)
-        log.debug('Looking for {0} in env'.format(key)))
+        log.debug('Looking for {0} in env'.format(key))
         log.debug(self._env)
         if isinstance(env_key, list):
             parent = self._find_insensitive(key, self._config)

--- a/vyper/vyper.py
+++ b/vyper/vyper.py
@@ -348,7 +348,7 @@ class Vyper(object):
                 return val
 
         env_key = self._find_insensitive(key, self._env)
-        log.debug(f'Looking for {key} in env')
+        log.debug('Looking for {0} in env'.format(key)))
         log.debug(self._env)
         if isinstance(env_key, list):
             parent = self._find_insensitive(key, self._config)
@@ -358,7 +358,6 @@ class Vyper(object):
             for item in env_key:
                 log.debug('{0} registered as env var parent {1}:'.format(key, item['env_key']))
                 val = self._get_env(item['env_key'])
-                
                 
                 if val is not None:
                     log.debug('{0} found in environment: {1}'.format(item['env_key'], val))


### PR DESCRIPTION
Hi! Sorry you've been getting so much activity from me, would have really liked to get this all in one PR. However, didn't think to look into this till after I discovered the insensitivity issue. This PR:

a) Allows for multiple env bindings deep in a complex binding where they share the same root. i.e.:
```python
v.bind_env('icings.regular', 'ICINGS_REGULAR')
v.bind_env('icings.premium', 'ICINGS_PREMIUM')
```

and

b) Respects the case insensitivity of env binding _while_ keeping key casing the same no matter what level of the config you pull.