### PR TITLE
Fixing nested default parameters

### DIFF
--- a/tests/test_vyper.py
+++ b/tests/test_vyper.py
@@ -175,6 +175,14 @@ class TestVyper(unittest.TestCase):
         self.v.set_default('state', 'NYC')
         self.assertEqual('NYC', self.v.get('state'))
 
+    def test_nested_default_post(self):
+        self._init_yaml()
+        self.assertTrue(self.v.is_set('clothing'))
+        self.assertFalse(self.v.is_set('clothing.gloves'))
+        self.assertNotEqual('leather', self.v.get('clothing.gloves'))
+        self.v.set_default('clothing.gloves', 'leather')
+        self.assertEqual('leather', self.v.get('clothing.gloves'))
+
     def test_aliases(self):
         self.v.register_alias('years', 'age')
         self.v.set('years', 45)

--- a/vyper/vyper.py
+++ b/vyper/vyper.py
@@ -325,8 +325,9 @@ class Vyper(object):
             source = self._find(path[0])
             if source is not None and isinstance(source, dict):
                 val = self._search_dict(source, path[1::])
-                log.debug('{0} found in nested config: {1}'.format(key, val))
-                return val
+                if val is not None:
+                    log.debug('{0} found in nested config: {1}'.format(key, val))
+                    return val
 
         val = self._kvstore.get(key)
         if val is not None:


### PR DESCRIPTION
When a default value is define for a nested parameter,
if the parent key exists in a data location but the nested key is not
the _find() will always return None instead of the default value.