### PR TITLE
fix merge when dict structures doesn't match

### DIFF
--- a/tests/test_vyper.py
+++ b/tests/test_vyper.py
@@ -547,3 +547,31 @@ class TestVyper(unittest.TestCase):
 
         self.v.merge_config(yaml.safe_dump(text(y)))
         self.assertEqual(self.v.get("a"), "xyz")
+
+    def test_merge_recurse_missing_source_key(self):
+        x = "a: abc"
+        y = """a: xyz
+b:
+  c: def"""
+        self.v.set_config_type("yaml")
+
+        self.v.read_config(yaml.safe_dump(text(x)))
+        self.assertEqual(self.v.get("a"), "abc")
+
+        self.v.merge_config(yaml.safe_dump(text(y)))
+        self.assertEqual(self.v.get("a"), "xyz")
+        self.assertEqual(self.v.get("b.c"), "def")
+
+    def test_merge_recurse_missing_destination_key(self):
+        x = """a: abc
+b:
+  c: xyz"""
+        y = "a: xyz"
+        self.v.set_config_type("yaml")
+
+        self.v.read_config(yaml.safe_dump(text(x)))
+        self.assertEqual(self.v.get("a"), "abc")
+
+        self.v.merge_config(yaml.safe_dump(text(y)))
+        self.assertEqual(self.v.get("a"), "xyz")
+        self.assertEqual(self.v.get("b.c"), "xyz")

--- a/vyper/vyper.py
+++ b/vyper/vyper.py
@@ -567,7 +567,7 @@ class Vyper(object):
 
     def _merge_dicts(self, src, target):
         for k, v in src.items():
-            if isinstance(v, dict):
+            if isinstance(v, dict) and k in target:
                 self._merge_dicts(v, target[k])
             else:
                 target[k] = v


### PR DESCRIPTION
See provided test, merge was failing when dict structure doesn't match.