### PR TITLE
Only install pathlib if python version < 3.4

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ setup(
     zip_safe=False,
     install_requires=[
         "distconfig>=0.1.0",
-        "pathlib>=1.0.1",
+        'pathlib>=1.0.1;python_version<"3.4"',
         "toml>=0.10.0",
         "PyYAML>=5.1",
         "watchdog>=0.9.0",


### PR DESCRIPTION
pathlib is only necessary for older versions of python and this backport is in fact deprecated for pathlib2. This will only install pathlib in python versions that require it.